### PR TITLE
Various dream detail changes

### DIFF
--- a/Defs/DreamDefs/Dreams/NegativeDreamDefs.xml
+++ b/Defs/DreamDefs/Dreams/NegativeDreamDefs.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Defs>
+
   <!--Hell-Like -->
   <DreamersDream.DreamDef ParentName="HellLikeDream">
     <defName>DreamDarkFigures</defName>
     <stages>
       <li>
         <label>Dreamt about dark figures</label>
-        <description>I was wandering around my place, when I saw shadowy figure coming out of the courner of the room. I asked it what it wants but it didn't respond. The figure was approaching me, being closer and closer with each second. I was panicking, the fear paralysed me. Then another figure appeared behind me. After that the figures grabbed me by my legs and arms. I screamed.</description>
+        <description>I was wandering around the colony when I saw a shadowy figure coming out of a dark corner. I asked it what it wants, but it didn't respond. The figure approached me, coming closer and closer with each second. I panicked, the fear paralysed me. Then another figure appeared behind me. After that, the figures grabbed me by my legs and arms. I screamed and everything went dark.</description>
         <baseMoodEffect>-11</baseMoodEffect>
       </li>
     </stages>
@@ -17,7 +18,7 @@
     <stages>
       <li>
         <label>Dreamt about moon crash</label>
-        <description>I awoke in my room. Felt a bit thirsty so I went to the kitchen to drink some water. Opened a window to let some fresh air in and there was an enormous moon, everything was shaking, almost like an earthquake was terrorizing the area. Orange light illuminated the surroundings. Buildings were floating here and there, like gravity never existed. The Moon was getting closer. The shaking got stronger. I heard some screams. Then some odd force hit me and I collapsed.</description>
+        <description>I awoke in my room <!--Can we replace this with the pawn's sleeping place? (Barracks/Bedroom?)-->. Felt a bit thirsty so I went to the kitchen to drink some water. Went outside to get some fresh air and there was an enormous moon up in the sky. Everything was shaking, almost like an earthquake was terrorizing the area. Orange light illuminated the surroundings. Buildings were floating here and there, like gravity had been turned off. The Moon came closer. The shaking got stronger. I heard screaming. Then some odd force hit me and I collapsed.</description>
         <baseMoodEffect>-11</baseMoodEffect>
       </li>
     </stages>
@@ -28,7 +29,7 @@
     <stages>
       <li>
         <label>Dreamt about tragic lives and deaths</label>
-        <description>I had to enter 7 tragical lives of people who had 7 tragical deaths. I lived 7 tragic lives and died 7 tragic deaths. 7... 7... 7..</description>
+        <description>I had to enter 7 tragical lives of people who had 7 tragical deaths. I lived 7 tragic lives and died 7 tragic deaths. 7... 7... 7...</description>
         <baseMoodEffect>-11</baseMoodEffect>
       </li>
     </stages>
@@ -37,13 +38,15 @@
     </tags>
     <dreamedBy>dambuk1</dreamedBy>
   </DreamersDream.DreamDef>
+
+
   <!--Terrorising-->
   <DreamersDream.DreamDef ParentName="TerrorisingDream">
     <defName>DreamWorldApart</defName>
     <stages>
       <li>
-        <label>Had a dream about Armageddon</label>
-        <description>I dreamt that whole world fell apart. It was a disaster.</description>
+        <label>Dreamt about Armageddon</label>
+        <description>I dreamt that the whole world fell apart. It was a disaster.</description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -52,8 +55,8 @@
     <defName>DreamSleepParalysis</defName>
     <stages>
       <li>
-        <label>Dark figure attacked during sleep</label>
-        <description>Some dark figure was sitting on my chest while I slept and I couldn't move!</description>
+        <label>Dreamt about being attacked</label>
+        <description>A dark figure was sitting on my chest and I couldn't move!</description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -63,7 +66,7 @@
     <stages>
       <li>
         <label>Dreamt about pile of corpses</label>
-        <description>I way lying on a huge pile of human corpses, some rotten, some fresh. I couldn't move. It was some kind of cargo section inside of a ship in the sea. From the pile crawled a rotten corpse and he grabbed my feet and bit off some toes. He crawled closer and tried to bite... well... that place... I woke up with pain in that place... ~Backrevol</description>
+        <description>I was lying on a huge pile of human corpses <!--Can we replace this with the pawn's species?-->, some rotten, some fresh. I couldn't move. It was some kind of cargo section inside of a ship in the ocean. From the pile crawled a rotten corpse and grabbed my feet and bit off some toes. It crawled closer and tried to bite... well... that place... I woke up with pain in that place...</description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -71,13 +74,14 @@
       <li>Nonpsycho</li>
       <li>Noncannibal</li>
     </tags>
+    <dreamedBy>Backrevol</dreamedBy>
   </DreamersDream.DreamDef>
   <DreamersDream.DreamDef ParentName="TerrorisingDream">
     <defName>DreamBrainJars</defName>
     <stages>
       <li>
-        <label>Dreamt about a brains in a glass jar</label>
-        <description>I was in the middle of some kind of secret archotech laboratory. All floors and walls were sterile. I explored the place for a while until I reached a warehouse which looked like it was hundreds of miles long. On every shelf there was a jar with brain with connected screen to it. I watched what was happening on those screens... someone was cooking meal... someone else was chased by some gangsters... someone else had sex... but then I saw truly extraordinary screen. Screen that was showing perspective of a man in a huge warehouse filled with jars with brains... </description>
+        <label>Dreamt about brain in a jar</label>
+        <description>I was in the middle of some kind of secret archotech laboratory. All surfaces were sterile and perfectly clean. I explored the place for a while until I reached a warehouse which looked like it was hundreds of miles long. On every shelf there was a jar with a brain, connected to a screen. I watched what was happening on those screens... Someone was cooking a meal... Someone else was chased by gangsters... Another person got some lovin'... but then I saw a truly extraordinary screen. It showed the perspective of a man in a huge warehouse filled with jars with brains... </description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -87,7 +91,7 @@
     <stages>
       <li>
         <label>Dreamt about meat locker</label>
-        <description>I was exploring our colony in the dark when I stumbled into the freezer. I saw shapes in the heavy mist hanging on meat hooks, and when I drew close I saw they were human bodies. They reached for me and I tried to turn away but there were more behind me, possessing the faces of people we've killed. They grabbed me and lift me onto a hook to stay there with them for all eternity...</description>
+        <description>I was exploring the colony in the dark when I stumbled into the freezer. I saw shapes in the heavy mist hanging on meat hooks, and when I drew close I saw that they were human. <!--Pawn/random humanoid species?--> They reached for me and I tried to turn away but there were more behind me, possessing the faces of people we have killed. They grabbed me and lifted me onto a hook to stay there with them for all eternity...</description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -102,7 +106,7 @@
     <stages>
       <li>
         <label>Dreamt about tiki-spider</label>
-        <description>I was in a humid, foreign jungle, trapped in a long ancient stone temple hallway. I turned around, and a spider with a tiki mask started chasing me. I woke up just before it pounced...</description>
+        <description>I was in a humid, foreign jungle, trapped in a long, ancient stone temple hallway. I turned around, and a spider with a tiki mask started chasing me. I woke up just before it pounced...</description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -113,7 +117,7 @@
     <stages>
       <li>
         <label>Dreamt about escaping a maze</label>
-        <description>I was running on what looked like hard packed dirt with little bits of graven and grass. As I ran I would often times have to make decisions on where to run, left or right, because the walls that blocked the way where clown and doll heads. I had to run a maze that was made out of clown and doll head, while something chased me. I woke up and was is a dry sweat and didn't want to open my eyes at all.</description>
+        <description>I was running on what looked like hard packed dirt with little bits of gravel and grass. As I ran I would often times have to make decisions on where to run, left or right, because the walls that blocked the way were clown and doll heads. I had to run a maze that was made out of a clown and doll head, while something chased me. I woke up and was in a dry sweat and didn't want to open my eyes at all.</description>
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -124,7 +128,8 @@
     <stages>
       <li>
         <label>Dreamt about fight among friends</label>
-        <description>Me and my best friend met in front of his house. We wanted to go biking together, and so we did. We were biking around many different places. When we were finally coming back home we saw a bunch of alligators climbing on a fence next to us. Scared, we biked away as fast as we could. After some time it got really cold outside, so we stopped under someone's house so we could dress up into heavier clothes. Suddenly, out of nowhere a tank appeared and shot at us. My best mate escaped with his bike leaving me alone. Sometime later I woke up at a house. It was the same house we stopped at to dress up. An old man was the owner and he was actually nice. My phone's battery was completely dead though. I wanted to go back home with my bike, but it was in pieces and some were missing. I walked home to tell my parents what happened. When I came back for my bike my other friends were taking it apart for parts. I had to fight them for my bike.</description>
+        <description>Me and my best friend <!--Can we reference them?--> met in front of their house. We wanted to go biking together, and so we did. We were biking around many different places. When we were finally coming back home we saw a bunch of alligators climbing on a fence next to us. Scared, we rode away as fast as we could. After some time it got really cold outside, so we stopped under someone's house so we could dress up into heavier clothes. Suddenly, out of nowhere, a tank appeared and shot at us. My friend escaped with their bike, leaving me alone. Sometime later I woke up at a house. It was the same house we stopped at to dress up. An old man was the owner and he was actually nice. My phone's battery was completely dead though. I wanted to go back home with my bike, but it was in pieces and some were missing. I walked home to tell my parents what happened. When I came back for my bike my other friends were taking it apart for parts. I had to fight them for my bike.</description>
+        <!--This dream references bikes, phones and general society outside of the Rimworlds. Should be restricted to non-tribal pawns.-->
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -135,14 +140,17 @@
     <stages>
       <li>
         <label>Dreamt about unfortunate marriage</label>
-        <description>I was in a small church, getting married to my ex who passed away years ago. My family was sitting on one side of the room, and the other side was where my ex's family was. The pastor was giving the ceremony, and we were holding hands, looking at each other. At one point, I slowly looked over to both our families. Nothing seemed out of the ordinary. Everything was fine. My family was sitting in the pews, as normal, my ex's as well. After looking at them, I looked at my ex. A few seconds later, I looked back at the families, and noticed something odd. Ex's family has changed into a random menagerie of canines. My family, was completely unphased. I look back at my ex which turned into greyish black werewolf, smirking, still holding my hands.</description>
+        <description>I was in a small church, getting married. My family was sitting on one side of the room, and the other side was where my fiance's family was. The pastor was giving the ceremony, and we were holding hands, looking at each other. At one point, I slowly looked over to both our families. Nothing seemed out of the ordinary. Everything was fine. My family was sitting in the pews, as normal, my fiance's as well. After looking at them, I looked at my fiance. A few seconds later, I looked back at the families, and noticed something odd. My fiance's family had changed into a random menagerie of canines. My family was completely unphased. I look back at my fiance which had turned into a greyish black werewolf, smirking, still holding my hands.</description>
+        <!--Can we restrict this to pawns with a fiance or lover?-->
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
     <dreamedBy>Lt. Vulfskrag</dreamedBy>
   </DreamersDream.DreamDef>
+
+
   <!--Frightening-->
-  <DreamersDream.DreamDef ParentName="FrighteningDream">
+<!--  <DreamersDream.DreamDef ParentName="FrighteningDream">
     <defName>DreamPolishVillage</defName>
     <tags>
       <li>Colonist</li>
@@ -156,12 +164,13 @@
     </stages>
     <dreamedBy>dambuk1</dreamedBy>
   </DreamersDream.DreamDef>
+This dream is very specifically about a person with a specific backstory. Not sure how to make this one make sense as a random dream for a random pawn. -Kas -->
   <DreamersDream.DreamDef ParentName="FrighteningDream">
     <defName>DreamMazeChildhood</defName>
     <stages>
       <li>
         <label>Dreamt about abandoned maze</label>
-        <description>I wandered around a labyrinth of rooms and hallways made up of my childhood home and locations I had previously visited, like my school and my friend's and family's houses.Everything was in black and white, and I had the feeling of being followed, or even chased at times. The rooms always looked run down, like they had been abandoned...</description>
+        <description>I wandered around a labyrinth of rooms and hallways made up of my childhood home and locations I had previously visited, like my school and my friend's and family's houses. Everything was in black and white, and I had the feeling of being followed, or even chased at times. The rooms always looked run down, like they had been abandoned...</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
@@ -175,7 +184,7 @@
     <stages>
       <li>
         <label>Dreamt about little dwarf</label>
-        <description>I dreamt I walked around the forest with my friend and a little dwarf ambushed us and stabbed my friend with a tiny knife!</description>
+        <description>I dreamt I walked around the forest with my friend and a little dwarf ambushed us and stabbed them with a tiny knife!</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
@@ -188,7 +197,7 @@
     <stages>
       <li>
         <label>Dreamt about destruction of colony</label>
-        <description>I was driving away from the colony I lived in. I had felt a strong sense of urgency, that I needed to get away yet I couldn't figure out why. As I walked up to the hill overlooking my home, I started to calm. As I reached the top, I sat down upon the grass under the trees and watched calmly as a small figure fell down from the boundless, blue sky. Only then, as the antigrain warhead went off did I understand why I felt that urgency.</description>
+        <description>I was walking away from the colony. I  felt a strong sense of urgency, that I needed to get away, yet I couldn't figure out why. As I walked up to the hill overlooking the colony <!--Can we put in the (dynamic) name of the colony here?-->, I started to calm. As I reached the top, I sat down upon the grass under the trees and watched calmly as a small figure fell down from the boundless, blue sky. Only then, as the antigrain warhead went off did I understand why I had felt that urgency.</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
@@ -199,7 +208,7 @@
     <stages>
       <li>
         <label>Dreamt about killing my favourite animal</label>
-        <description>I had to kill my pet by strangling it, I was squeezing its little throat with both hands and it wouldn't die and just kept looking at me with its big green eyes. I was sobbing uncontrollably in the dream but I had to just keep trying to kill it.</description>
+        <description>I had to kill my pet <!--Bonded pet name here?--> by strangling it, I was squeezing its throat with both hands and it wouldn't die and just kept looking at me with its big soft eyes. I was sobbing uncontrollably in the dream but I had to just keep trying to kill it.</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
@@ -213,7 +222,7 @@
     <stages>
       <li>
         <label>Dreamt about distant danger</label>
-        <description>I had a dream in which I walked around the colony. After a few moments I realised that my head was rolling down the hill away from our home. I chased it until it stopped. After finally regaining my precious head, I looked around. Everything was burned to the ground and the only sounds were coming from strange machinery spitting out mechanoids...</description>
+        <description>I had a dream in which I walked around the colony. After a few moments I realised that my head was rolling down the hill away from our home. I chased it until it stopped. After finally regaining my precious head, I looked around. Everything was burned to the ground and the only sounds were coming from strange machinery spitting out ancient mechanoids...</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
@@ -277,11 +286,13 @@
     <stages>
       <li>
         <label>Dreamt about stealing honey</label>
-        <description>I was in some kind of magical forest. After walking a few miles I noticed big bee hive. I was hungry, so I put my hand in it to snatch some honey but when I took it out there was no honey... but maggots.</description>
+        <description>I was in some kind of magical forest. After walking a few miles I noticed a big bee hive. I was hungry, so I put my hand in it to snatch some honey but when I took it out there was no honey... only wiggling maggots.</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
   </DreamersDream.DreamDef>
+
+
   <!--Disturbing -->
   <DreamersDream.DreamDef ParentName="DisturbingDream">
     <defName>DreamBanditCowboy</defName>
@@ -291,7 +302,8 @@
     <stages>
       <li>
         <label>Dreamt about bandit cowboy</label>
-        <description> A cowboy was calling on a radio. The entire colony gathered to chat with him. Half were charmed by his outlandish tales, half felt he was sketchy. He wanted to join, together with his giant boomalope. After a long discussion, he was refused, but he still insisted on passing through the colony. He led the boomalope through our fields and when he was in the middle of our crops, near the windmills... he released the 'lope and ran like hell. Then came the bandits. He was part of the bandits... and the boomalope exploding was the sign for the attack. </description>
+        <description> A cowboy called us on the radio. The entire colony gathered to chat with him. Half were charmed by his outlandish tales, half felt he was sketchy. He wanted to join us, along with his giant boomalope. After a long discussion, he was refused, but he still insisted on passing through the colony. He led the boomalope through our fields and when he was in the middle of our crops, near the windmills... he released the 'lope and ran like hell. Then came the bandits. He was part of the bandits... and the boomalope exploding was the sign for the attack.</description>
+        <!--restrict to colonists -->
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -323,7 +335,7 @@
     <stages>
       <li>
         <label>Dreamt about killing</label>
-        <description>I was killing... But I didn't want to...</description>
+        <description>I killed without mercy... But I didn't want to...</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -349,7 +361,7 @@
     <stages>
       <li>
         <label>Dreamt about starvation</label>
-        <description>I was starving... I was begging people to help me... But they wouldn't!</description>
+        <description>I was starving... I begged people to help me... But they wouldn't!</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -365,7 +377,7 @@
     <stages>
       <li>
         <label>Dreamt about being in prison</label>
-        <description>I was asking them to let me out... I was innocent...</description>
+        <description>I asked them to let me out... I was innocent...</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -375,7 +387,7 @@
     <stages>
       <li>
         <label>Dreamt about childhood</label>
-        <description>I relived some of the worst moments from my childhood.</description>
+        <description>I relived some of the worst moments from my childhood. <!--Put in child bio?--></description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -385,7 +397,7 @@
     <stages>
       <li>
         <label>Dreamt about insects</label>
-        <description>They were crawling everywhere. Millions of bugs and worms were chasing me. I woke up the moment they got me...</description>
+        <description>They were crawling everywhere. Millions of bugs and worms were chasing me. At least I woke up the moment they got me...</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -408,7 +420,7 @@
     <stages>
       <li>
         <label>Dreamt about social exclusion</label>
-        <description>In my dream I was excluded from my friendship group because I was scared to snort Yayo...</description>
+        <description>I was excluded from my group because I was scared to snort Yayo... Do we even have any Yayo?</description>
         <baseMoodEffect>-3</baseMoodEffect>
       </li>
     </stages>
@@ -456,7 +468,7 @@
       <li>
         <label>Can't recall a bad dream</label>
         <description>I dreamt about something upsetting but I don't really remember what it was...</description>
-        <baseMoodEffect>-1</baseMoodEffect>
+        <baseMoodEffect>-2</baseMoodEffect>
       </li>
     </stages>
   </DreamersDream.DreamDef>
@@ -484,9 +496,10 @@
     <defName>ExDream</defName>
     <stages>
       <li>
-        <label>Dreamt about my ex partners</label>
+        <label>Dreamt about my ex partner</label>
         <description>I don't want you back in my life! Stop bothering me in my sleep!</description>
         <baseMoodEffect>-2</baseMoodEffect>
+        <!--Can we restrict this to pawns with former partners or lovers?-->
       </li>
     </stages>
   </DreamersDream.DreamDef>
@@ -549,6 +562,7 @@
       <li>
         <label>Dreamt about redhead with beard</label>
         <description>It started off at school, where I began to realize something was wrong. Everyone I saw looked like they could barely contain themselves from instantly becoming violent, and they had this look in their eyes like they had just spotted the best prey they had ever seen, but were held back by something. I remember thinking "No way, I'm out", and ran home as fast as I could. Some of it is blurry, but I remember coming across people that I knew, either friends or family, or people from the neighborhood, telling me to get home, that it's not safe. Finally I make it there, put the key in the front door, open it, and I am literally surrounded by all of those same people, only now they look like the ones at school, and there stands the redhead with the beard. Without saying a word she lunges at me and pierces my neck with her fangs. </description>
+        <!--Restrict to modern tech-->
         <baseMoodEffect>-8</baseMoodEffect>
       </li>
     </stages>
@@ -606,21 +620,11 @@
       </li>
     </stages>
   </DreamersDream.DreamDef>
+
+
+
   <!-- New Dreams -->
 </Defs>
-<!--    <DreamersDream.DreamDef ParentName="BaseDream">
-<defName>DreamGeneric</defName>
-<tags>
-  <li>Colonist</li>
-</tags>
-<stages>
-  <li>
-    <label>Dreamt about darkness</label>
-    <description> A cowboy was calling on a radio. The entire colony gathered to chat with him. Half were charmed by his outlandish tales, half felt he was sketchy. He wanted to join, together with his giant boomalope. After a long discussion, he was refused, but he still insisted on passing through the colony. He led the boomalope through our fields and when he was in the middle of our crops, near the windmills... he released the 'lope and ran like hell. Then came the bandits. He was part of the bandits... and the boomalope exploding was the sign for the attack. </description>
-    <baseMoodEffect>-3</baseMoodEffect>
-  </li>
-</stages>
-</DreamersDream.DreamDef>-->
 <!--<DreamersDream.DreamDef ParentName = "BaseDream">
 <defName>TravelDreamUlthar</defName>
 <stages>

--- a/Defs/DreamDefs/Dreams/PositiveDreamDefs.xml
+++ b/Defs/DreamDefs/Dreams/PositiveDreamDefs.xml
@@ -9,7 +9,7 @@
     <stages>
       <li>
         <label>Dreamt about tourist spaceship</label>
-        <description>I was one of the high-ranking officers in white uniform. Me, and some others were on a cubical, tourist, 2 miles long spaceship. The command center was located in a tower in the middle of the ship, deep within instead of the outer shell of spacecraft. The weirdest thing was that the ship captain was a 3 feet tall rat in white uniform. Everyone respected him. One time, a canadian hockey player in his hockey uniform with the helmet on decided to visit our ship. We welcomed him aboard, and everyone was happy. While we were walking along side the footbal field, we saw a tank, and the rat was controlling it. Our rat captain pointed the tank's barrel towards the hockey player, and I had to run in front of the hockey player for it to cease fire and not shoot the hockey player. The tank stopped, and then started driving away. As it started moving backwards, we were cheering. I showed the hockey player inside the ship, where there was a ton of supermarket-like shops, one of them was hanging on the ropes. After that in some time I lost the hockey player, but then he came back, thanked me for my service and left. After a while we got news that the captain was killed in an explosion. I rushed to the top of the tower with the command center, and I entered a luxury apartament on the very top of the tower. I saw through a courner that the rat was indeed killed, but not by an explosion. We mourned his death for a while, and one of the officers of equivalent rank to mine took control, and decided to stop the tour. I told him repetitevly to bring me to my hometown because we were close to it, but he wouldn't listen.</description>
+        <description> I was on a huge, cubical spaceship. The command center was located in a tower in the middle of the ship, deep within instead of the outer shell of the craft. The weirdest thing was that the ship captain was a 3 feet tall rat in the same white uniform I was wearing, too. Everyone respected him. One time, a canadian hockey player in his hockey uniform with the helmet on decided to visit our ship. We welcomed him aboard, and everyone was happy. While we were walking alongside the football field, we saw a tank, and the rat was controlling it. Our rat captain pointed the tank's barrel towards the hockey player, and I had to run in front of the hockey player for it to cease fire and not shoot the hockey player. The tank stopped, and then started driving away. As it started moving backwards, we were cheering. I showed the hockey player inside the ship, where there was a ton of supermarket-like shops, one of them was hanging on the ropes. After that in some time I lost the hockey player, but then he came back, thanked me for my service and left. After a while we got news that the captain was killed in an explosion. I rushed to the top of the tower with the command center, and I entered a luxury apartment at the very top. I saw through a corner that the rat was indeed killed, but not by an explosion. We mourned his death for a while, and one of the officers of equivalent rank to mine took control, and decided to stop the tour. I told him repetitevly to bring me to my colony because we were close to it, but he wouldn't listen.</description>
         <baseMoodEffect>3</baseMoodEffect>
       </li>
     </stages>
@@ -24,7 +24,8 @@
     <stages>
       <li>
         <label>Dreamt about heroic defence</label>
-        <description>I had to defend our colony against waves and waves of upcoming serpent-like monsters while also sending units to enable some form of passage. It took place on a fiery planet, lots of lava, lots of fire and the sky was red. It goes on for quite a while but in the end units manage to open the passage. I board a shuttle and head towards strange gate which allows for connection of our world to abyss. While trying to do that I meet my friend who was apparently trapped on this shuttle. I free him and go close the gate. I succeed. Everyone is cheering, calling me a hero, we have a party and I can recognize most of my friends, old friends who I have lost contact with long ago. Everyone is dancing, music is playing and I get to dance with someone I love... </description>
+        <description>I had to defend our colony against waves and waves of upcoming serpent-like monsters while also sending units to enable some form of passage. It took place on a fiery planet, lots of lava, lots of fire and the sky was red. It went on for quite a while but in the end the monsters managed to open the passage. I boarded a shuttle and headed towards a strange gate which allowed for connection of our world to the abyss. While trying to do that I met my friend who was apparently trapped on this shuttle. I freed him and went to close the gate. Somehow, I succeeded. Everyone cheered, calling me a hero, and went on to have a party. I recognized most of my friends, even old friends who I have lost contact with long ago. Everyone was dancing, music played and I got to dance with someone I love... </description>
+        <!--restrict to colonists-->
         <baseMoodEffect>12</baseMoodEffect>
       </li>
     </stages>
@@ -45,7 +46,7 @@
     <stages>
       <li>
         <label>Dreamt about meeting ancient god</label>
-        <description>I was sitting on a grassy hill surrounded by mountains full of trees and green white grass. After a while, tall old man with round hat and staff approached me. There were two crows sitting on the staff. He said "look" and pointed to the horizon and then a old viking came up right next to me leaning on a tree with a battered shield and said to me "Grunts would be pigs if they knew what the old boar was suffering". Out of nowhere trees and hills are on fire. The old man looked at me and said "Valhalla is coming for you. Don't forget me."</description>
+        <description>I was sitting on a grassy hill surrounded by mountains full of trees and green white grass. After a while, a tall old man with round hat and staff approached me. There were two crows sitting on the staff. He said "look" and pointed to the horizon and then an old viking came up right next to me leaning on a tree with a battered shield and said to me "Grunts would be pigs if they knew what the old boar was suffering". Out of nowhere the trees and hills were set on fire. The old man looked at me and said "Valhalla is coming for you. Don't forget me."</description>
         <baseMoodEffect>12</baseMoodEffect>
       </li>
     </stages>
@@ -69,6 +70,7 @@
         <label>Dreamt about animal competition</label>
         <description>I joined a dog-sledding competition, which was a racetrack where the dogs ski around a track for several laps. I cheated by putting on my dog's uniform and entering the race as my dog (and giving my dog my clothes so he can look like me cheering him on). I went through the whole race, skiing stiffly to look like a dog skiing, but at the very end I felt guilty about cheating and bumped into a pole so I'd get second place. 7' tall Bruce Willis knew that I cheated and got back at me by standing very close to me and making me look short.</description>
         <baseMoodEffect>8</baseMoodEffect>
+        <!-- Change this to random animal species, maybe? -->
       </li>
     </stages>
     <dreamedBy>Mitroll</dreamedBy>
@@ -90,6 +92,7 @@
         <label>Dreamt about fire tornado</label>
         <description>I was wandering through a jungle until I noticed a giant fire tornado. It simply stood there, not burning anything - the ground around it was burnt and barren but around it was a lush wild, rain forest. There were some locals worshipping it. They told me that it was The Element and explained the lore of Elementals. Elements are aspects of reality that humanity sees as important and symbolic - they can be as basic as "fire" or as complicated as "chaos" or "jealousy". They are simultaneously Gods, Worlds and Hive Minds of living beings - smaller elementals that might think that they act of free will. But elementals are not free - they act as the Element as a whole wills them. This tornado of fire is a high level Elemental and it needs constant worship which the locals do in shifts. If they stop, it will spread fire all around and feed on our fear of it.</description>
         <baseMoodEffect>8</baseMoodEffect>
+        <!-- Considering how many dreams there are that only make sense for non-tribals, this might very well only be for tribals. -->
       </li>
     </stages>
     <dreamedBy>dambuk1</dreamedBy>
@@ -102,6 +105,7 @@
         <label>Dreamt about being a racoon</label>
         <description>I was a small animal (I think it was a raccoon?) in a random windy forest. It was pretty nice even if all I did was wander around and occasionally see other creatures, and at some point I think I befriended a groundhog. I'm not too sure on how it ended but the last thing I vaguely remember was seeing buildings over a hill. ~~okoyum</description>
         <baseMoodEffect>6</baseMoodEffect>
+        <!-- only tribals? -->
       </li>
     </stages>
     <tags>
@@ -143,7 +147,7 @@
     <stages>
       <li>
         <label>Dreamt about doing good job</label>
-        <description>I was tasked to build strange shapes which looked like a four triangles connected side by side. I gathered immense amounts of stone and helped little people finish the yellow construction. The little humans were so happy with my work that they decided to place their kings there after death!</description>
+        <description>I was tasked to build strange shapes which looked like four triangles connected side by side. I gathered immense amounts of stone and helped little people finish the yellow construction. The little humans were so happy with my work that they decided to place their kings there after death!</description>
         <baseMoodEffect>6</baseMoodEffect>
       </li>
     </stages>
@@ -192,7 +196,7 @@
     <stages>
       <li>
         <label>Dreamt about partying naked</label>
-        <description>I was walking around colony, when I realised that I'm wearing no clothes! I looked around and noticed that everyone took off their clothes as they saw me! We started to drink and dance around our home naked.</description>
+        <description>I was walking around the colony, when I realised that I'm wearing no clothes! I looked around and noticed that everyone took off their clothes as they saw me! We started to drink and dance naked.</description>
         <baseMoodEffect>5</baseMoodEffect>
       </li>
     </stages>
@@ -205,7 +209,7 @@
     <stages>
       <li>
         <label>Dreamt about flying</label>
-        <description>I was flying in my dream dream! It was an amazing experience. I just wanted it to keep going...</description>
+        <description>I was flying in my dream dream! It was an amazing experience. I just wanted to keep going...</description>
         <baseMoodEffect>5</baseMoodEffect>
       </li>
     </stages>
@@ -237,7 +241,7 @@
     <stages>
       <li>
         <label>Dreamt about childhood</label>
-        <description>I was back in my childhood house! I've regained connection with some of my the best memories.</description>
+        <description>I was back in my childhood house! I've regained connection with some of my best memories.</description>
         <baseMoodEffect>2</baseMoodEffect>
       </li>
     </stages>
@@ -266,7 +270,7 @@
     <defName>DreamPleasentThings</defName>
     <stages>
       <li>
-        <label>Dreamt about pleasent things</label>
+        <label>Dreamt about pleasant things</label>
         <description>I don't really remember my dreams from tonight, but when I awoke I simply felt better.</description>
         <baseMoodEffect>2</baseMoodEffect>
       </li>
@@ -291,7 +295,7 @@
     <stages>
       <li>
         <label>Dreamt about cheese</label>
-        <description>Cheese.... Cheese everywhere!</description>
+        <description>Cheese... Cheese everywhere!</description>
         <baseMoodEffect>2</baseMoodEffect>
       </li>
     </stages>
@@ -317,7 +321,7 @@
     <stages>
       <li>
         <label>Dreamt about murdering rival</label>
-        <description>I wish we could still be here. To see how much I'm enjoying now, after ending his miserable life...</description>
+        <description>I wish they could still be here. To see how much I'm enjoying myself now, after ending their miserable life...</description>
         <baseMoodEffect>8</baseMoodEffect>
       </li>
     </stages>


### PR DESCRIPTION
--Removed all mentiones of "I dreamt..." in the dream description, as this is already in the title
--References to the pawn's home now vaguely refer to their colony
--References to specific locations made slightly more consistent
--References to the pawn's past are now more vague in accordance with their various backstories
--Made NSFW references a teeny bit more SFW
--All references to places on Earth have been removed and, if possible, changed to fitting generic worlds.
--Added a whole bunch of comments in various places about adding dynamic details in dreams in the future